### PR TITLE
fix retry for EventDispatcher.send

### DIFF
--- a/celery/events/__init__.py
+++ b/celery/events/__init__.py
@@ -215,7 +215,8 @@ class EventDispatcher(object):
                 headers=self.headers,
             )
 
-    def send(self, type, blind=False, **fields):
+    def send(self, type, blind=False, utcoffset=utcoffset, retry=False,
+             retry_policy=None, Event=Event, **fields):
         """Send event.
 
         :param type: Event type name, with group separated by dash (`-`).
@@ -235,7 +236,9 @@ class EventDispatcher(object):
             if groups and group_from(type) not in groups:
                 return
             try:
-                self.publish(type, fields, self.producer, blind)
+                self.publish(type, fields, self.producer, retry=retry,
+                             retry_policy=retry_policy, blind=blind,
+                             utcoffset=utcoffset, Event=Event)
             except Exception as exc:
                 if not self.buffer_while_offline:
                     raise


### PR DESCRIPTION
Проблема: при попытке отправить сообщение через EventDispatcher нет ни сообщения на принимающей стороне, ни исключения на отправляющей. Наверно, стоит начать с того, чтобы пофиксить celery с тем чтобы включить retry при отправке (+ реконнект неявно)
